### PR TITLE
Updated scripts for Apple Photos version 4.0 and added album to folder script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pictures in it while preserving:
 * Edits (exports the original and all edits for each image)
 
 The program writes as much metadata as it can directly into the images using EXIF. (See http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/XMP.html for information about supported tags.)
-This program worked on the database format around 2016-08. Apple has since changed the naming of some files, and this script no longer works, though it might with some small fixes. I do not have access to the new format, so I can't test it. However, feel free to update it and open a pull request!
+This program worked on the database format around 2019-07, Apple Photos version 4.0 .
 
 The program operates in distinct phases, which can all be run independently:
 
@@ -50,6 +50,11 @@ Run as:
 
   ```shell
   $ ./group_versions.py <output_dir>
+  ```
+
+* Album folders: copy all photo's in folders according to the albums they are in. If a photo is in two different albums, it will be copied in two different folders, each folder with the name of the album. Run as:
+  ```shell
+  $ ./album_folder.py <source_dir> <output_dir>
   ```
 
 To run all the phases together (except for group photos), run:

--- a/album_folder.py
+++ b/album_folder.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python3
+
+import json
+import progressbar
+import os
+import sys
+from shutil import copyfile
+
+def run(source_dir, output_dir):
+    bar = progressbar.ProgressBar()
+    for f in bar(os.listdir(source_dir)):
+        if os.path.splitext(f)[1] == '.json':
+            with open(os.path.join(source_dir, f)) as data_file:
+                data = json.load(data_file)
+                for album in data['albums']:
+                    album = album.replace("/", "_")
+                    if not os.path.exists(os.path.join(output_dir, album)):
+                        os.mkdir(os.path.join(output_dir, album))
+
+                    imagesource = data['path']
+                    imagename = data['path'].split(os.sep)[-1]
+                    imagedestination = os.path.join(output_dir, album, imagename)
+
+                    copyfile(imagesource, imagedestination)
+
+# Usage: ./album_folder <source_dir> <output_dir>
+# Copies all files from source_dir to a folder-based map structure in output_dir
+# Useful for programs like Plex, who expect a folder-based structure for pictures
+if __name__ == '__main__':
+    run(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
I fixed the scripts to work for the current version of Apple Photos - version 4.0

I also added a script album_folder.py that auto-copies the images into folders according to the metadata into album folders. I needed that, so if I can do someone a pleasure, I figure it has a place in this repo.

Also fixed a small bug where images that should be present according to the database and were in reality not present would crash the script.

Tested on a library of 120 GB so deemed tested.

Greets,

Zeno