### PR TITLE
Favorite to rating

### DIFF
--- a/extract_photos.py
+++ b/extract_photos.py
@@ -150,8 +150,7 @@ def run(lib_dir, output_dir):
             rating = version['mainRating']
 
             # rating used just in old iPhoto. this converts a Favorite photo to rating 5
-            favorite = version['isFavorite']
-            if favorite == 1:
+            if version['isFavorite'] == 1:
                 rating = 5
 
             if is_master:


### PR DESCRIPTION
Rating is used only in old iPhoto. The new Photos.app we can only set a photo is Favorite or not.
This modification checks if a photo is marked as favorite and set its rating to 5 if it is. If its not favorite, the rating remains 0. 

I don't know if it is right (noobie in github), but this branch should be created under the branch keywords_not_extracting, since this is base on that. Please, check if the later is applied first.