### PR TITLE
Ignore trashed images

### DIFF
--- a/extract_photos.py
+++ b/extract_photos.py
@@ -3,12 +3,9 @@
 import sys
 import os
 import sqlite3
-import hashlib
 import json
 import progressbar
-import uuid
 import shutil
-from libxmp import XMPFiles
 
 global count
 
@@ -129,7 +126,7 @@ def run(lib_dir, output_dir):
             wc.execute(
                 'SELECT * FROM RKKeywordForVersion WHERE versionId=?', [version['modelId']])
             keywords = set([])
-            for keyword_id in iter(kc.fetchone, None):
+            for keyword_id in iter(wc.fetchone, None):
                 klc = main_db.cursor()
                 klc.execute('SELECT * FROM RKKeyword WHERE modelId=?',
                             [keyword_id['keywordId']])

--- a/extract_photos.py
+++ b/extract_photos.py
@@ -3,12 +3,12 @@
 import sys
 import os
 import sqlite3
-import hashlib
+#import hashlib
 import json
 import progressbar
-import uuid
+#import uuid
 import shutil
-from libxmp import XMPFiles
+#from libxmp import XMPFiles
 
 global count
 
@@ -129,7 +129,7 @@ def run(lib_dir, output_dir):
             wc.execute(
                 'SELECT * FROM RKKeywordForVersion WHERE versionId=?', [version['modelId']])
             keywords = set([])
-            for keyword_id in iter(kc.fetchone, None):
+            for keyword_id in iter(wc.fetchone, None):
                 klc = main_db.cursor()
                 klc.execute('SELECT * FROM RKKeyword WHERE modelId=?',
                             [keyword_id['keywordId']])

--- a/extract_photos.py
+++ b/extract_photos.py
@@ -80,6 +80,11 @@ def run(lib_dir, output_dir):
         for version in iter(vc.fetchone, None):
             edited_path = []
             is_master = False
+
+            # ignore if version was deleted of Library
+            if version['isInTrash'] == 1:
+                continue
+
             if version['adjustmentUuid'] != 'UNADJUSTEDNONRAW':
                 ac = proxy_db.cursor()
                 ac.execute('SELECT * FROM RKModelResource WHERE resourceTag=?',

--- a/extract_photos.py
+++ b/extract_photos.py
@@ -73,6 +73,11 @@ def run(lib_dir, output_dir):
         master_albums = set([])
         master_keywords = set([])
         master_rating = None
+
+        # ignore image if it is in trash
+        if master['isInTrash']:
+            continue
+
         vc = main_db.cursor()
         vc.execute('SELECT * FROM RKVersion WHERE masterUuid=?', [master_uuid])
         edited_paths = []


### PR DESCRIPTION
This branch was also based under the keywords_not_exporting branch.

I noticed that even photos marked as DELETED on Photos.app was being exported. 
the original script knows that and just mark in_library to FALSE in JSON, but the image file is still exported. 

This change ignores if the file or a version if it is trashed, making the image and JSON file not be exported.