### PR TITLE
Preserve folder structure of Photos.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ pictures in it while preserving:
 * Keywords (as tags)
 * Ratings
 * Edits (exports the original and all edits for each image)
+* Folder and Album structure (photos not included in any album will be placed on ROOT of destination directory)
 
 The program writes as much metadata as it can directly into the images using EXIF. (See http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/XMP.html for information about supported tags.)
-This program worked on the database format around 2019-07, Apple Photos version 4.0 .
+This program worked on the database format around 2019-07, Apple Photos version 4.0 (also tested in a Apple Photos 3.0 with about 100.000 photos).
 
 The program operates in distinct phases, which can all be run independently:
 
@@ -51,8 +52,17 @@ Run as:
   ```shell
   $ ./group_versions.py <output_dir>
   ```
+* Folder Structure: Reads Library Database and generates a file (folders.json) with all information necessary to replicate the folder structure contained in Photos.app. Place the destination file within the output directory with exported photos. Run as:
+  ```shell
+  $ ./folder_structure.py <library_dir> <output_dir>
+  ```
 
-* Album folders: copy all photo's in folders according to the albums they are in. If a photo is in two different albums, it will be copied in two different folders, each folder with the name of the album. Run as:
+* Albums Data: Reads Library Database and generates a file (albums.json) with all information necessary to place the album inside the right folder. Place the destination file within the output directory with exported photos. Run as:
+  ```shell
+  $ ./albums_data.py <library_dir> <output_dir>
+  ```
+
+* Album folders: copy/move all photo's in folders according to the albums they are in. If a photo is in two different albums, it will be copied in two different folders, each folder with the name of the album. Run as:
   ```shell
   $ ./album_folder.py <source_dir> <output_dir>
   ```

--- a/album_folder.py
+++ b/album_folder.py
@@ -54,7 +54,6 @@ def run(source_dir, output_dir, verbose):
         if ext != '.json' or filename in SYSTEM_FILES:
             continue
 
-        print ("Processing File: ", f)
         num_of_json += 1
         with open(os.path.join(source_dir, f)) as data_file:
             data = json.load(data_file)

--- a/album_folder.py
+++ b/album_folder.py
@@ -105,8 +105,6 @@ def run(source_dir, output_dir, verbose):
 
                     album_fullpath = os.path.join(output_dir, album_folder, album_name)
 
-                    print("Final Album Path: ", album_fullpath)
-
                     if not os.path.exists(album_fullpath):
                         # Create the album on destination directory
                         os.makedirs(album_fullpath, exist_ok=True)

--- a/album_folder.py
+++ b/album_folder.py
@@ -14,6 +14,8 @@ SYSTEM_FILES = ["albums.json", "folders.json"]
 
 # Source_dir : passed as parameter, where your photos are located
 # output_dir : directory under where all albuns will be created
+
+
 def run(source_dir, output_dir, verbose):
     def vprint(x):
         if verbose:
@@ -44,8 +46,11 @@ def run(source_dir, output_dir, verbose):
 
         folders_file = open(folders_path)
         folders_dict = json.load(folders_file)
-    except:
-        print("Error loading Albums or Folders system file.\n\t", albums_path, folders_path)
+    except BaseException:
+        print(
+            "Error loading Albums or Folders system file.\n\t",
+            albums_path,
+            folders_path)
         sys.exit(1)
 
     for f in bar(all_files):
@@ -102,14 +107,16 @@ def run(source_dir, output_dir, verbose):
                     folder_id = albums_dict[album_id][1]
                     album_folder = folders_dict[folder_id][1]
 
-                    album_fullpath = os.path.join(output_dir, album_folder, album_name)
+                    album_fullpath = os.path.join(
+                        output_dir, album_folder, album_name)
 
                     if not os.path.exists(album_fullpath):
                         # Create the album on destination directory
                         os.makedirs(album_fullpath, exist_ok=True)
                         num_of_albuns += 1
 
-                    imagedestination = os.path.join(album_fullpath, file_original_name)   # change destination to inside album
+                    imagedestination = os.path.join(
+                        album_fullpath, file_original_name)   # change destination to inside album
 
                     if album_counter == number_of_albums:
                         # let's not consider the photo was exported or will
@@ -139,6 +146,7 @@ def run(source_dir, output_dir, verbose):
     vprint('Total files moved: {}'.format(num_of_moved))
     vprint('Total files duplicated to albuns: {}'.format(num_of_copied))
 
+
 # Usage: ./album_folder <source_dir> <output_dir>
 # Copies all files from source_dir to a folder-based map structure in output_dir
 # Useful for programs like Plex, who expect a folder-based structure for
@@ -159,7 +167,7 @@ if __name__ == '__main__':
 
     try:
         args = parser.parse_args()
-    except:
+    except BaseException:
         sys.exit(2)
 
     start_time = time.time()

--- a/album_folder.py
+++ b/album_folder.py
@@ -5,10 +5,12 @@ import progressbar
 import os
 import sys
 import time
+import datetime
 from argparse import ArgumentParser
 from shutil import copyfile
 from shutil import move
 
+SYSTEM_FILES = ["albums.json", "folders.json"]
 
 # Source_dir : passed as parameter, where your photos are located
 # output_dir : directory under where all albuns will be created
@@ -27,17 +29,32 @@ def run(source_dir, output_dir, verbose):
     num_of_albuns = 0
     num_of_copied = 0
     num_of_moved = 0
-    num_of_total_files = 0
     num_of_json = 0
 
     all_files = os.listdir(source_dir)
     num_of_total_files = len(all_files)
 
+    # load albums and folders data file
+    albums_path = os.path.join(source_dir, SYSTEM_FILES[0])
+    folders_path = os.path.join(source_dir, SYSTEM_FILES[1])
+
+    try:
+        albums_file = open(albums_path)
+        albums_dict = json.load(albums_file)
+
+        folders_file = open(folders_path)
+        folders_dict = json.load(folders_file)
+    except:
+        print("Error loading Albums or Folders system file.\n\t", albums_path, folders_path)
+        sys.exit(1)
+
     for f in bar(all_files):
         (root_file, ext) = os.path.splitext(f)
-        if ext != '.json':
+        filename = os.path.basename(f)
+        if ext != '.json' or filename in SYSTEM_FILES:
             continue
 
+        print ("Processing File: ", f)
         num_of_json += 1
         with open(os.path.join(source_dir, f)) as data_file:
             data = json.load(data_file)
@@ -76,19 +93,27 @@ def run(source_dir, output_dir, verbose):
                     num_of_missing += 1
             # this is where the photo is included in some album
             else:
-                # list of all albums the photo is included
-                for album in data['albums']:
-                    album = album.replace('/', '_')
-                    if not os.path.exists(os.path.join(output_dir, album)):
+                # get the list of all albums UUIDs the photo is included
+                for album_id in data['albums']:
+                    album_name = albums_dict[album_id][0]
+                    album_name = album_name.replace(os.path.sep, '_')
+
+                    # mount the final path of the Album, based in its UUID.
+                    # get the folder path from folders dict
+                    folder_id = albums_dict[album_id][1]
+                    album_folder = folders_dict[folder_id][1]
+
+                    album_fullpath = os.path.join(output_dir, album_folder, album_name)
+
+                    print("Final Album Path: ", album_fullpath)
+
+                    if not os.path.exists(album_fullpath):
                         # Create the album on destination directory
-                        os.mkdir(os.path.join(output_dir, album))
+                        os.makedirs(album_fullpath, exist_ok=True)
                         num_of_albuns += 1
 
-                    imagedestination = os.path.join(
-                        output_dir, album, file_original_name)   # change destination to inside album
+                    imagedestination = os.path.join(album_fullpath, file_original_name)   # change destination to inside album
 
-                    # temporary commented, until tested it all right, no
-                    # copies, no moves.
                     if album_counter == number_of_albums:
                         # let's not consider the photo was exported or will
                         # raise an exception

--- a/album_folder.py
+++ b/album_folder.py
@@ -107,8 +107,9 @@ def run(source_dir, output_dir, verbose):
                     folder_id = albums_dict[album_id][1]
                     album_folder = folders_dict[folder_id][1]
 
-                    album_fullpath = os.path.join(
-                        output_dir, album_folder, album_name)
+                    # build and normalize path to current OS
+                    album_fullpath = os.path.normpath(os.path.join(
+                        output_dir, album_folder, album_name))
 
                     if not os.path.exists(album_fullpath):
                         # Create the album on destination directory

--- a/albums_data.py
+++ b/albums_data.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-#     This script reads ans stores all Albums seneitive  information
+#     This script reads ans stores all Albums sensitive  information
 #  from Photos.app, used to store a Album on the right Folder it should go
 #  Generates a JSON file of the information to be used later
 #

--- a/albums_data.py
+++ b/albums_data.py
@@ -11,23 +11,28 @@ import sys
 import sqlite3
 
 # SOME CONSTANTS USED
-ALBUM_TABLE="RKAlbum"
-FOLDER_TABLE="RKFolder"
+ALBUM_TABLE = "RKAlbum"
+FOLDER_TABLE = "RKFolder"
 
-UUID_FIELD="uuid"
-NAME_FIELD="name"
-TRASH_FIELD="isInTrash"
-MODELID_FIELD="modelId"
+UUID_FIELD = "uuid"
+NAME_FIELD = "name"
+TRASH_FIELD = "isInTrash"
+MODELID_FIELD = "modelId"
 
-FOLDER_FIELD="folderUuid"
+FOLDER_FIELD = "folderUuid"
 
 
 # Ignore all albuns inside these folders. consider only user created
-IGNORED_FOLDERS_ALBUNS = ['LibraryFolder', 'TopLevelAlbums', 'MediaTypesSmartAlbums', 'TopLevelSlideshows', 'TrashFolder']
-JSON_FILENAME="albums.json"
+IGNORED_FOLDERS_ALBUNS = [
+    'LibraryFolder',
+    'TopLevelAlbums',
+    'MediaTypesSmartAlbums',
+    'TopLevelSlideshows',
+    'TrashFolder']
+JSON_FILENAME = "albums.json"
 
 # helper function, to debug
-#def print_dict(dicionario):
+# def print_dict(dicionario):
 #   print("--  Dicionario: --")
 #    for key, val in dicionario.items():
 #        print(key, "=>", val)
@@ -54,17 +59,17 @@ def run(lib_dir, output_dir):
         if album[TRASH_FIELD] == 1:
             continue
 
-        album_name      = album[NAME_FIELD]
-        album_uuid      = album[UUID_FIELD]
-        album_folder    = album[FOLDER_FIELD]
-        album_modelid   = album[MODELID_FIELD]
+        album_name = album[NAME_FIELD]
+        album_uuid = album[UUID_FIELD]
+        album_folder = album[FOLDER_FIELD]
+        album_modelid = album[MODELID_FIELD]
 
         # add to dictionary
-        if album_folder not in IGNORED_FOLDERS_ALBUNS and album_name != None:
+        if album_folder not in IGNORED_FOLDERS_ALBUNS and album_name is not None:
             #album_name = album_name.replace('/', '_')
             db_album_dict[album_uuid] = [album_name, album_folder]
 
-    #print_dict(db_album_dict)
+    # print_dict(db_album_dict)
 
     #  mount and store final JSON on file
     json_albums = json.dumps(db_album_dict)
@@ -72,7 +77,6 @@ def run(lib_dir, output_dir):
     json_file = open(json_path, "w")
     json_file.write(json_albums)
     json_file.close()
-
 
 
 # Usage: ./folder_structure.py <photo_library> <output_dir>

--- a/albums_data.py
+++ b/albums_data.py
@@ -61,6 +61,7 @@ def run(lib_dir, output_dir):
 
         # add to dictionary
         if album_folder not in IGNORED_FOLDERS_ALBUNS and album_name != None:
+            #album_name = album_name.replace('/', '_')
             db_album_dict[album_uuid] = [album_name, album_folder]
 
     #print_dict(db_album_dict)

--- a/albums_data.py
+++ b/albums_data.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+
+#     This script reads ans stores all Albums seneitive  information
+#  from Photos.app, used to store a Album on the right Folder it should go
+#  Generates a JSON file of the information to be used later
+#
+import json
+import progressbar
+import os
+import sys
+import sqlite3
+
+# SOME CONSTANTS USED
+ALBUM_TABLE="RKAlbum"
+FOLDER_TABLE="RKFolder"
+
+UUID_FIELD="uuid"
+NAME_FIELD="name"
+TRASH_FIELD="isInTrash"
+MODELID_FIELD="modelId"
+
+FOLDER_FIELD="folderUuid"
+
+
+# Ignore all albuns inside these folders. consider only user created
+IGNORED_FOLDERS_ALBUNS = ['LibraryFolder', 'TopLevelAlbums', 'MediaTypesSmartAlbums', 'TopLevelSlideshows', 'TrashFolder']
+JSON_FILENAME="albums.json"
+
+# helper function, to debug
+#def print_dict(dicionario):
+#   print("--  Dicionario: --")
+#    for key, val in dicionario.items():
+#        print(key, "=>", val)
+#    print("----------------------------------")
+
+
+def run(lib_dir, output_dir):
+    db_path = os.path.join(lib_dir, 'database')
+    main_db_path = os.path.join(db_path, 'photos.db')
+
+    main_db = sqlite3.connect(main_db_path)
+    main_db.row_factory = sqlite3.Row
+
+    # Get all albums information
+    album_table = main_db.cursor()
+    album_table.execute('SELECT * FROM ' + ALBUM_TABLE)
+
+    # will store uuid -> [name, folder]
+    db_album_dict = {}
+
+    # let's test each album
+    for album in iter(album_table.fetchone, None):
+        # Ignore Trashed albums
+        if album[TRASH_FIELD] == 1:
+            continue
+
+        album_name      = album[NAME_FIELD]
+        album_uuid      = album[UUID_FIELD]
+        album_folder    = album[FOLDER_FIELD]
+        album_modelid   = album[MODELID_FIELD]
+
+        # add to dictionary
+        if album_folder not in IGNORED_FOLDERS_ALBUNS and album_name != None:
+            db_album_dict[album_uuid] = [album_name, album_folder]
+
+    #print_dict(db_album_dict)
+
+    #  mount and store final JSON on file
+    json_albums = json.dumps(db_album_dict)
+    json_path = os.path.join(output_dir, JSON_FILENAME)
+    json_file = open(json_path, "w")
+    json_file.write(json_albums)
+    json_file.close()
+
+
+
+# Usage: ./folder_structure.py <photo_library> <output_dir>
+if __name__ == '__main__':
+    run(sys.argv[1], sys.argv[2])

--- a/clean_albums.py
+++ b/clean_albums.py
@@ -27,6 +27,7 @@ def run(root):
                 with open(os.path.join(root, f), 'w') as output:
                     print(json.dumps(data), file=output)
 
+
 # Usage: ./clean_albums.py <export_dir>
 # Removes all albums whose names are just dates
 if __name__ == '__main__':

--- a/extract_photos.py
+++ b/extract_photos.py
@@ -128,7 +128,7 @@ def run(lib_dir, output_dir):
                         print(
                             "Warning! More than one album for ID %d" %
                             album_id['albumId'])
-                    albums |= set([r_albums[0]['name']])
+                    albums |= set([r_albums[0]['uuid']])
 
             wc = main_db.cursor()
             wc.execute(
@@ -184,6 +184,10 @@ def run(lib_dir, output_dir):
         if unadjusted_count != 0 and unadjusted_count != 1:
             # print("Warning! %d unadjusted images!" % unadjusted_count)
             pass
+
+        # create output_dir if not exists
+        if not os.path.isdir(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
 
         if os.path.isfile(master_path):
             # Export!

--- a/extract_photos.py
+++ b/extract_photos.py
@@ -48,7 +48,8 @@ def run(lib_dir, output_dir):
 
     namer = gen_name()
 
-    # Map below doesn't seem to exist anymore. Leaving this here in case someone finds it.
+    # Map below doesn't seem to exist anymore. Leaving this here in case
+    # someone finds it.
 
     # edited_root = os.path.join(lib_dir, 'resources', 'modelresources')
     # edited_index = {}
@@ -100,7 +101,7 @@ def run(lib_dir, output_dir):
                            [version['adjustmentUuid']])
                 for resource in iter(ac.fetchone, None):
                     if resource['attachedModelType'] == 2 and resource[
-                        'resourceType'] == 4:
+                            'resourceType'] == 4:
                         if len(edited_path) != 0:
                             pass
                             # print("Warning! Multiple valid edits!")
@@ -148,7 +149,8 @@ def run(lib_dir, output_dir):
 
             rating = version['mainRating']
 
-            # rating used just in old iPhoto. this converts a Favorite photo to rating 5
+            # rating used just in old iPhoto. this converts a Favorite photo to
+            # rating 5
             if version['isFavorite'] == 1:
                 rating = 5
 

--- a/folder_structure.py
+++ b/folder_structure.py
@@ -24,13 +24,11 @@ FOLDER_MODELID="modelId"
 IGNORED_FOLDERS = ['LibraryFolder', 'TopLevelAlbums', 'MediaTypesSmartAlbums', 'TopLevelSlideshows', 'TrashFolder']
 JSON_FILENAME="folders.json"
 
-
-
-def print_dict(dicionario):
-    print("--  Dicionario: --")
-    for key, val in dicionario.items():
-        print(key, "=>", val)
-    print("----------------------------------")
+#def print_dict(dicionario):
+#    print("--  Dicionario: --")
+#    for key, val in dicionario.items():
+#        print(key, "=>", val)
+#    print("----------------------------------")
 
 
 def split_path(path):
@@ -70,8 +68,6 @@ def run(lib_dir, output_dir):
         #print("Adicionando... KEY/UUID/NAME/PATH", folder_modelid, folder_uuid, folder_name, folder_path)
         db_folder_dict[folder_modelid] = [folder_uuid, folder_name, folder_path]
 
-    print_dict(db_folder_dict)
-
     # Dict ready. Let's substitute the Paths and return a simpler dict
     final_dict = {}
     for key,val in db_folder_dict.items():
@@ -91,9 +87,6 @@ def run(lib_dir, output_dir):
 
                     path_described += folder_name   # Change folder number to Folder name
                     final_dict[key_uuid] = [name, path_described]
-
-    print("Final Dict (uuid=>name,path):")
-    print_dict(final_dict)
 
     #  mount and store final JSON on file
     json_folders = json.dumps(final_dict)

--- a/folder_structure.py
+++ b/folder_structure.py
@@ -1,0 +1,109 @@
+#! /usr/bin/env python3
+
+#     This script reads Folder structure from Photos.app
+#  and generates a JSON file to be reproduced on export, creating
+#  a structure identical with the albuns inside it.
+#
+import json
+import progressbar
+import os
+import sys
+import sqlite3
+
+# SOME CONSTANTS USED
+ALBUM_TABLE="RKAlbum"
+FOLDER_TABLE="RKFolder"
+UUID_FIELD="uuid"
+NAME_FIELD="name"
+TRASH_FIELD="isInTrash"
+
+ALBUM_FOLDER_FIELD="folderUuid"
+FOLDER_PATH_FIELD="folderPath"
+FOLDER_MODELID="modelId"
+
+IGNORED_FOLDERS = ['LibraryFolder', 'TopLevelAlbums', 'MediaTypesSmartAlbums', 'TopLevelSlideshows', 'TrashFolder']
+JSON_FILENAME="folders.json"
+
+
+
+def print_dict(dicionario):
+    print("--  Dicionario: --")
+    for key, val in dicionario.items():
+        print(key, "=>", val)
+    print("----------------------------------")
+
+
+def split_path(path):
+    folders = path.split('/')
+    return folders
+
+
+def run(lib_dir, output_dir):
+    db_path = os.path.join(lib_dir, 'database')
+    main_db_path = os.path.join(db_path, 'photos.db')
+    proxy_db_path = os.path.join(db_path, 'photos.db')
+
+    main_db = sqlite3.connect(main_db_path)
+    main_db.row_factory = sqlite3.Row
+    proxy_db = sqlite3.connect(proxy_db_path)
+    proxy_db.row_factory = sqlite3.Row
+
+    # PASSO1: Pega a tabela de todas as pastas
+    folders_table = main_db.cursor()
+    folders_table.execute('SELECT * FROM ' + FOLDER_TABLE)
+
+    # will store modelID -> [FOLDERNAME, PATH]
+    db_folder_dict = {}
+
+    # PASSO2: Para cada pasta listada,
+    for folder in iter(folders_table.fetchone, None):
+        # Ignore Trashed Folders
+        if folder[TRASH_FIELD] == 1:
+            continue
+
+        folder_path     = folder[FOLDER_PATH_FIELD]
+        folder_name     = folder[NAME_FIELD]
+        folder_uuid     = folder[UUID_FIELD]
+        folder_modelid  = folder[FOLDER_MODELID]
+
+        # add to dictionary
+        #print("Adicionando... KEY/UUID/NAME/PATH", folder_modelid, folder_uuid, folder_name, folder_path)
+        db_folder_dict[folder_modelid] = [folder_uuid, folder_name, folder_path]
+
+    print_dict(db_folder_dict)
+
+    # Dict ready. Let's substitute the Paths and return a simpler dict
+    final_dict = {}
+    for key,val in db_folder_dict.items():
+        path_numbered = val[2]                          # get the path in numbers
+        key_uuid = val[0]                            # the key for the final dict
+        name = val[1]
+
+        path_described = ""
+        for number in path_numbered.split('/'):
+            if number != "":                     # the last will always be empty, ignore
+                int_number = int(number)
+                folder_name = db_folder_dict[int_number][1]
+                folder_uuid = db_folder_dict[int_number][0]
+                if folder_uuid not in IGNORED_FOLDERS:
+                    if path_described != "":
+                        path_described += os.path.sep
+
+                    path_described += folder_name   # Change folder number to Folder name
+                    final_dict[key_uuid] = [name, path_described]
+
+    print("Final Dict (uuid=>name,path):")
+    print_dict(final_dict)
+
+    #  mount and store final JSON on file
+    json_folders = json.dumps(final_dict)
+    json_path = os.path.join(output_dir, JSON_FILENAME)
+    json_file = open(json_path, "w")
+    json_file.write(json_folders)
+    json_file.close()
+
+
+
+# Usage: ./folder_structure.py <photo_library> <output_dir>
+if __name__ == '__main__':
+    run(sys.argv[1], sys.argv[2])

--- a/folder_structure.py
+++ b/folder_structure.py
@@ -39,12 +39,9 @@ def split_path(path):
 def run(lib_dir, output_dir):
     db_path = os.path.join(lib_dir, 'database')
     main_db_path = os.path.join(db_path, 'photos.db')
-    proxy_db_path = os.path.join(db_path, 'photos.db')
 
     main_db = sqlite3.connect(main_db_path)
     main_db.row_factory = sqlite3.Row
-    proxy_db = sqlite3.connect(proxy_db_path)
-    proxy_db.row_factory = sqlite3.Row
 
     # PASSO1: Pega a tabela de todas as pastas
     folders_table = main_db.cursor()

--- a/folder_structure.py
+++ b/folder_structure.py
@@ -11,20 +11,25 @@ import sys
 import sqlite3
 
 # SOME CONSTANTS USED
-ALBUM_TABLE="RKAlbum"
-FOLDER_TABLE="RKFolder"
-UUID_FIELD="uuid"
-NAME_FIELD="name"
-TRASH_FIELD="isInTrash"
+ALBUM_TABLE = "RKAlbum"
+FOLDER_TABLE = "RKFolder"
+UUID_FIELD = "uuid"
+NAME_FIELD = "name"
+TRASH_FIELD = "isInTrash"
 
-ALBUM_FOLDER_FIELD="folderUuid"
-FOLDER_PATH_FIELD="folderPath"
-FOLDER_MODELID="modelId"
+ALBUM_FOLDER_FIELD = "folderUuid"
+FOLDER_PATH_FIELD = "folderPath"
+FOLDER_MODELID = "modelId"
 
-IGNORED_FOLDERS = ['LibraryFolder', 'TopLevelAlbums', 'MediaTypesSmartAlbums', 'TopLevelSlideshows', 'TrashFolder']
-JSON_FILENAME="folders.json"
+IGNORED_FOLDERS = [
+    'LibraryFolder',
+    'TopLevelAlbums',
+    'MediaTypesSmartAlbums',
+    'TopLevelSlideshows',
+    'TrashFolder']
+JSON_FILENAME = "folders.json"
 
-#def print_dict(dicionario):
+# def print_dict(dicionario):
 #    print("--  Dicionario: --")
 #    for key, val in dicionario.items():
 #        print(key, "=>", val)
@@ -56,20 +61,23 @@ def run(lib_dir, output_dir):
         if folder[TRASH_FIELD] == 1:
             continue
 
-        folder_path     = folder[FOLDER_PATH_FIELD]
-        folder_name     = folder[NAME_FIELD]
-        folder_uuid     = folder[UUID_FIELD]
-        folder_modelid  = folder[FOLDER_MODELID]
+        folder_path = folder[FOLDER_PATH_FIELD]
+        folder_name = folder[NAME_FIELD]
+        folder_uuid = folder[UUID_FIELD]
+        folder_modelid = folder[FOLDER_MODELID]
 
         # add to dictionary
         #print("Adicionando... KEY/UUID/NAME/PATH", folder_modelid, folder_uuid, folder_name, folder_path)
-        db_folder_dict[folder_modelid] = [folder_uuid, folder_name, folder_path]
+        db_folder_dict[folder_modelid] = [
+            folder_uuid, folder_name, folder_path]
 
     # Dict ready. Let's substitute the Paths and return a simpler dict
     final_dict = {}
-    for key,val in db_folder_dict.items():
-        path_numbered = val[2]                          # get the path in numbers
-        key_uuid = val[0]                            # the key for the final dict
+    for key, val in db_folder_dict.items():
+        # get the path in numbers
+        path_numbered = val[2]
+        # the key for the final dict
+        key_uuid = val[0]
         name = val[1]
 
         path_described = ""
@@ -91,7 +99,6 @@ def run(lib_dir, output_dir):
     json_file = open(json_path, "w")
     json_file.write(json_folders)
     json_file.close()
-
 
 
 # Usage: ./folder_structure.py <photo_library> <output_dir>

--- a/group_versions.py
+++ b/group_versions.py
@@ -58,6 +58,7 @@ def run(root):
     db.commit()
     db.close()
 
+
 # Usage: ./group_version.py <digikam_dir>
 if __name__ == '__main__':
     run(sys.argv[1])

--- a/photos_export.py
+++ b/photos_export.py
@@ -3,20 +3,53 @@
 import clean_albums
 import extract_photos
 import set_exif
+import albums_data
+import folder_structure
+import group_versions
+import album_folder
 import sys
 
 
 def output(thing):
     print('>>> %s' % thing)
 
+def askyesno():
+    answer = None
+    while answer not in ("yes", "no"):
+        answer = input("Enter yes or no: ")
+        if answer == "yes":
+            return True
+        elif answer == "no":
+            return False
+        else:
+            print("Please enter yes or no.")
 
 def run(lib_dir, output_dir):
+    temp_dir = os.path.join(output_dir, "temporaryfolder")
+
     output('Extracting photos')
-    extract_photos.run(lib_dir, output_dir)
+    extract_photos.run(lib_dir, temp_dir)
+
     output('Cleaning album names')
-    clean_albums.run(output_dir)
+    clean_albums.run(temp_dir)
+
     output('Setting EXIF metadata')
-    set_exif.run(output_dir)
+    set_exif.run(temp_dir)
+
+    output("ONLY FOR DIGIKAM USERS !\nDo you want to Group Versions ? You need to run Digikam and configure repository first !")
+    if askyesno():
+        output('Setting EXIF metadata')
+        group_versions.run(temp_dir)
+
+    output('Exporting Folder Structure')
+    folder_structure.run(lib_dir, temp_dir)
+
+    output('Exporting Albums Structure Information')
+    albums_data.run(lib_dir, temp_dir)
+
+    output('Moving Photos to final destination.')
+    album_folder.run(temp_dir, output_dir)
+
 
 
 # Usage: ./photos_export.py <photo_library> <output_dir>

--- a/photos_export.py
+++ b/photos_export.py
@@ -18,6 +18,7 @@ def run(lib_dir, output_dir):
     output('Setting EXIF metadata')
     set_exif.run(output_dir)
 
+
 # Usage: ./photos_export.py <photo_library> <output_dir>
 if __name__ == '__main__':
     run(sys.argv[1], sys.argv[2])

--- a/set_exif.py
+++ b/set_exif.py
@@ -65,6 +65,7 @@ def run(root):
                         exec_opts(opts +
                                   ['-overwrite_original_in_place', '-P'], img_file)
 
+
 # Usage: ./set_exif.py <output_dir>
 if __name__ == '__main__':
     run(sys.argv[1])


### PR DESCRIPTION
This is a huge change.
the original program extracts all albums from Photos.app and creates all of them in the ROOT of OUTPUT dir. If there are any album with the same name they will be merged. 
In this version, the folder structure that was created in Photos.app are now replicated as folders under output_dir. The albums inside the folders are also replicated and the photos are copied inside the albums they belongs. No merge anymore, if a photo is present on several albums it will be replcated to the right album inside a folder, even if there's another album with the same name on another folder.
Photos not present on any album are places on root of output dir. 

For that, several changes were made in four files:
- two new JSON files are created (albums.json and folders.json) to help decide where to send each photo. (**folder_structure.py** and **albums_data.py**)
- **extract_photos.py** now stores albums IDs, instead of albums names.
- those albums IDs are translated with those JSON files and the folder/album are composed to copy the file. (**album_folder.py**) 

I didin't think yet about code optimization. It's a step ahead. 
Altrhough my editor has PEP8 checking integrated, I ran autoppep8 using format.sh
Tested on a small sample database of my own.