### PR TITLE
Ignore deleted albums fix

### DIFF
--- a/albums_data.py
+++ b/albums_data.py
@@ -20,23 +20,9 @@ TRASH_FIELD = "isInTrash"
 MODELID_FIELD = "modelId"
 
 FOLDER_FIELD = "folderUuid"
+ROOT_FOLDER = "TopLevelAlbums"
 
-
-# Ignore all albuns inside these folders. consider only user created
-IGNORED_FOLDERS_ALBUNS = [
-    'LibraryFolder',
-    'TopLevelAlbums',
-    'MediaTypesSmartAlbums',
-    'TopLevelSlideshows',
-    'TrashFolder']
 JSON_FILENAME = "albums.json"
-
-# helper function, to debug
-# def print_dict(dicionario):
-#   print("--  Dicionario: --")
-#    for key, val in dicionario.items():
-#        print(key, "=>", val)
-#    print("----------------------------------")
 
 
 def run(lib_dir, output_dir):
@@ -48,25 +34,21 @@ def run(lib_dir, output_dir):
 
     # Get all albums information
     album_table = main_db.cursor()
-    album_table.execute('SELECT * FROM ' + ALBUM_TABLE)
+    album_table.execute('SELECT * FROM ' + ALBUM_TABLE + ' WHERE ' + TRASH_FIELD + '=0')
 
     # will store uuid -> [name, folder]
     db_album_dict = {}
 
     # let's test each album
     for album in iter(album_table.fetchone, None):
-        # Ignore Trashed albums
-        if album[TRASH_FIELD] == 1:
-            continue
 
         album_name = album[NAME_FIELD]
         album_uuid = album[UUID_FIELD]
         album_folder = album[FOLDER_FIELD]
-        album_modelid = album[MODELID_FIELD]
+        album_folder = album_folder.replace(ROOT_FOLDER, "")
 
         # add to dictionary
-        if album_folder not in IGNORED_FOLDERS_ALBUNS and album_name is not None:
-            #album_name = album_name.replace('/', '_')
+        if album_name is not None:
             db_album_dict[album_uuid] = [album_name, album_folder]
 
     # print_dict(db_album_dict)

--- a/extract_photos.py
+++ b/extract_photos.py
@@ -9,10 +9,7 @@ import shutil
 
 global count
 
-
 # Generates a unique suffix
-
-
 def gen_name():
     count = 0
     while True:
@@ -25,8 +22,6 @@ def gen_name():
 
 
 # Generates a unique suffix
-
-
 def next_name(path, namer):
     next(namer)
     return namer.send(path)
@@ -84,7 +79,7 @@ def run(lib_dir, output_dir):
             continue
 
         vc = main_db.cursor()
-        vc.execute('SELECT * FROM RKVersion WHERE masterUuid=?', [master_uuid])
+        vc.execute('SELECT * FROM RKVersion WHERE masterUuid=? and isInTrash=0', [master_uuid])
         edited_paths = []
         unadjusted_count = 0
         for version in iter(vc.fetchone, None):
@@ -92,8 +87,8 @@ def run(lib_dir, output_dir):
             is_master = False
 
             # ignore if version was deleted of Library
-            if version['isInTrash'] == 1:
-                continue
+            #if version['isInTrash'] == 1:
+            #   continue
 
             if version['adjustmentUuid'] != 'UNADJUSTEDNONRAW':
                 ac = proxy_db.cursor()
@@ -121,7 +116,7 @@ def run(lib_dir, output_dir):
             albums = set([])
             for album_id in iter(kc.fetchone, None):
                 alc = main_db.cursor()
-                alc.execute('SELECT * FROM RKAlbum WHERE modelId=?',
+                alc.execute('SELECT * FROM RKAlbum WHERE modelId=? and isInTrash=0',
                             [album_id['albumId']])
                 r_albums = alc.fetchall()
                 if len(r_albums) != 0:
@@ -129,7 +124,7 @@ def run(lib_dir, output_dir):
                         print(
                             "Warning! More than one album for ID %d" %
                             album_id['albumId'])
-                    albums |= set([r_albums[0]['uuid']])
+                    albums |= {r_albums[0]['uuid']}
 
             wc = main_db.cursor()
             wc.execute(
@@ -145,7 +140,7 @@ def run(lib_dir, output_dir):
                         print(
                             "Warning! More than one keyword for ID %d" %
                             keyword_id['keywordId'])
-                    keywords |= set([r_keyword[0]['name']])
+                    keywords |= {r_keyword[0]['name']}
 
             rating = version['mainRating']
 
@@ -198,9 +193,9 @@ def run(lib_dir, output_dir):
             shutil.copy2(
                 master_path,
                 os.path.join(
-                    output_dir,
-                    iuuid +
-                    os.path.splitext(master_path)[1].lower()))
+                   output_dir,
+                   iuuid +
+                   os.path.splitext(master_path)[1].lower()))
             # Write the data
             with open(os.path.join(output_dir, '%s.json' % iuuid), 'w') as log_file:
                 print(
@@ -208,7 +203,7 @@ def run(lib_dir, output_dir):
                         dict(master_data, derived_from=None)),
                     file=log_file)
             # Copy the edits
-            edit_export_path = os.path.join(base_export_path, 'edited')
+            #edit_export_path = os.path.join(base_export_path, 'edited')
             for edit_info in edited_paths:
                 shutil.copy2(
                     edit_info['path'],

--- a/folder_structure.py
+++ b/folder_structure.py
@@ -27,13 +27,8 @@ IGNORED_FOLDERS = [
     'MediaTypesSmartAlbums',
     'TopLevelSlideshows',
     'TrashFolder']
-JSON_FILENAME = "folders.json"
 
-# def print_dict(dicionario):
-#    print("--  Dicionario: --")
-#    for key, val in dicionario.items():
-#        print(key, "=>", val)
-#    print("----------------------------------")
+JSON_FILENAME = "folders.json"
 
 
 def split_path(path):
@@ -48,18 +43,14 @@ def run(lib_dir, output_dir):
     main_db = sqlite3.connect(main_db_path)
     main_db.row_factory = sqlite3.Row
 
-    # PASSO1: Pega a tabela de todas as pastas
     folders_table = main_db.cursor()
-    folders_table.execute('SELECT * FROM ' + FOLDER_TABLE)
+    folders_table.execute('SELECT * FROM ' + FOLDER_TABLE + ' WHERE isInTrash=0')
 
     # will store modelID -> [FOLDERNAME, PATH]
     db_folder_dict = {}
 
     # PASSO2: Para cada pasta listada,
     for folder in iter(folders_table.fetchone, None):
-        # Ignore Trashed Folders
-        if folder[TRASH_FIELD] == 1:
-            continue
 
         folder_path = folder[FOLDER_PATH_FIELD]
         folder_name = folder[NAME_FIELD]
@@ -67,7 +58,6 @@ def run(lib_dir, output_dir):
         folder_modelid = folder[FOLDER_MODELID]
 
         # add to dictionary
-        #print("Adicionando... KEY/UUID/NAME/PATH", folder_modelid, folder_uuid, folder_name, folder_path)
         db_folder_dict[folder_modelid] = [
             folder_uuid, folder_name, folder_path]
 


### PR DESCRIPTION
Trying to export my official library, got on a lot of trouble with photos not included in any album because the configuration of ignore some albums inside folders (that makes the USER albums inside ToplevelAlbuns to be ignored too.
Also, since Photos.app organizes it filenames as it's imported by date/time including seconds, files with same filenames that will go to the same Album will be overwritten. This change fixes this issue by keeping the exported generated filename to the original file and putting it on destination directory.
