### PR TITLE
Fix group versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The program operates in distinct phases, which can all be run independently:
 Run as:
 
   ```shell
-  $ ./group_versions.py <output_dir>
+  $ ./group_versions.py <digikam_db_dir> <photos_dir>
   ```
 * Folder Structure: Reads Library Database and generates a file (folders.json) with all information necessary to replicate the folder structure contained in Photos.app. Place the destination file within the output directory with exported photos. Run as:
   ```shell

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pictures in it while preserving:
 * GPS location data
 * Albums (as tags)
 * Keywords (as tags)
-* Ratings
+* Rating (Favorite photos get 5 of rating. Others get 0)
 * Edits (exports the original and all edits for each image)
 * Folder and Album structure (photos not included in any album will be placed on ROOT of destination directory)
 
@@ -46,7 +46,7 @@ The program operates in distinct phases, which can all be run independently:
   ```shell
   $ ./set_exif.py <output_dir>
   ```
-* Group versions: the script is digikam specific. Before running this script, import the photos into digikam. Launch digikam at least once, then close it. Then, run this script to write all the photo version and edit information into digikam's database so digikam can group edited photos.
+* Group versions: the script is DIGIKAM specific. Before running this script, import the photos into digikam. Launch digikam at least once, then close it. Then, run this script to write all the photo version and edit information into digikam's database so digikam can group edited photos.
 Run as:
 
   ```shell
@@ -67,10 +67,10 @@ Run as:
   $ ./album_folder.py <source_dir> <output_dir>
   ```
 
-To run all the phases together (except for group photos), run:
+To run all the phases together (digikam phase is optional, answer no if you omit the last parameter), run:
 
 ```shell
-$ ./photos_export.py <foo.photoslibrary> <output_dir>
+$ ./photos_export.py <foo.photoslibrary> <output_dir> [digikam_db_dir]
 ```
 
 All the scripts have nice progress bars.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Run as:
   $ ./album_folder.py <source_dir> <output_dir>
   ```
 
-To run all the phases together (digikam phase is optional, answer no if you omit the last parameter), run:
+To run all the phases together (digikam phase is optional, omit the last parameter if you do not want to run), run:
 
 ```shell
 $ ./photos_export.py <foo.photoslibrary> <output_dir> [digikam_db_dir]

--- a/album_folder.py
+++ b/album_folder.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
         help='Path of where the .json and photos were exported')
     parser.add_argument(
         'output_dir',
-        help='Path to where the albuns and the files will be created/moved')
+        help='Path to where the albums and the files will be created/moved')
 
     try:
         args = parser.parse_args()

--- a/group_versions.py
+++ b/group_versions.py
@@ -23,10 +23,15 @@ def image_id(db, name):
     return rows[0]['id']
 
 
-def run(digikam_dir, photos_dir, digikam_dir):
+def run(digikam_dir, photos_dir):
     db_path = os.path.join(digikam_dir, 'digikam4.db')
-    db = sqlite3.connect(db_path)
-    db.row_factory = sqlite3.Row
+
+    try:
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+    except Exception as error:
+        print("Error connecting to DIGIKAM DB: ", error)
+        sys.exit(1)
 
     bar = progressbar.ProgressBar()
     for photo_file in bar(os.listdir(photos_dir)):
@@ -58,4 +63,4 @@ def run(digikam_dir, photos_dir, digikam_dir):
 
 # Usage: ./group_version.py <digikam_dir> <photos_dir>
 if __name__ == '__main__':
-    run(sys.argv[1], sys.argv[2], sys.argv[3])
+    run(sys.argv[1], sys.argv[2])

--- a/group_versions.py
+++ b/group_versions.py
@@ -3,11 +3,10 @@
 import json
 import progressbar
 import os
-import queue
 import sys
 import sqlite3
 import glob
-from dateutil import parser
+from argparse import ArgumentParser
 
 # Digikam format
 # edited_id original_id 2
@@ -23,28 +22,26 @@ def image_id(db, name):
         raise RuntimeError('Too many matches for "%s": %i' % (name, len(rows)))
     return rows[0]['id']
 
-# Run on the output folder (should be the root digikam folder)
 
-
-def run(root):
-    db_path = os.path.join(root, 'digikam4.db')
+def run(digikam_dir, photos_dir, digikam_dir):
+    db_path = os.path.join(digikam_dir, 'digikam4.db')
     db = sqlite3.connect(db_path)
     db.row_factory = sqlite3.Row
 
     bar = progressbar.ProgressBar()
-    for f in bar(os.listdir(root)):
-        found_ext = os.path.splitext(f)[1]
+    for photo_file in bar(os.listdir(photos_dir)):
+        found_ext = os.path.splitext(photo_file)[1]
         if found_ext != '.json' and found_ext != '.db':
             json_file = os.path.join(
-                root, os.path.splitext(f)[0] + '.json')
-            img_file = os.path.join(root, f)
+                photos_dir, os.path.splitext(photo_file)[0] + '.json')
+            img_file = os.path.join(photos_dir, photo_file)
             with open(json_file) as data_file:
                 data = json.load(data_file)
                 derived_from = data['derived_from']
                 if derived_from is not None:
                     edited_id = image_id(db, img_file)
                     possible_originals = glob.glob(
-                        os.path.join(root, derived_from) + '.*')
+                        os.path.join(photos_dir, derived_from) + '.*')
                     possible_originals = [
                         item for item in possible_originals if os.path.splitext(item)[1] != '.json']
                     if len(possible_originals) != 1:
@@ -59,6 +56,6 @@ def run(root):
     db.close()
 
 
-# Usage: ./group_version.py <digikam_dir>
+# Usage: ./group_version.py <digikam_dir> <photos_dir>
 if __name__ == '__main__':
-    run(sys.argv[1])
+    run(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/photos_export.py
+++ b/photos_export.py
@@ -8,10 +8,12 @@ import folder_structure
 import group_versions
 import album_folder
 import sys
+from argparse import ArgumentParser
 
 
 def output(thing):
     print('>>> %s' % thing)
+
 
 def askyesno():
     answer = None
@@ -24,7 +26,8 @@ def askyesno():
         else:
             print("Please enter yes or no.")
 
-def run(lib_dir, output_dir):
+
+def run(lib_dir, output_dir, digikam_dir):
     temp_dir = os.path.join(output_dir, "temporaryfolder")
 
     output('Extracting photos')
@@ -36,10 +39,11 @@ def run(lib_dir, output_dir):
     output('Setting EXIF metadata')
     set_exif.run(temp_dir)
 
-    output("ONLY FOR DIGIKAM USERS !\nDo you want to Group Versions ? You need to run Digikam and configure repository first !")
+    output("ONLY FOR DIGIKAM USERS !\nDo you want to Group Versions ? You need to run Digikam and configure "
+           "repository first !")
     if askyesno():
         output('Setting EXIF metadata')
-        group_versions.run(temp_dir)
+        group_versions.run(digikam_dir, temp_dir)
 
     output('Exporting Folder Structure')
     folder_structure.run(lib_dir, temp_dir)
@@ -51,7 +55,23 @@ def run(lib_dir, output_dir):
     album_folder.run(temp_dir, output_dir)
 
 
-
-# Usage: ./photos_export.py <photo_library> <output_dir>
+# Usage: ./photos_export.py <photo_library> <output_dir> <digikam_dir>
+# digikam_dir may be any dir, if you want to ignore it.
 if __name__ == '__main__':
-    run(sys.argv[1], sys.argv[2])
+    parser = ArgumentParser()
+    parser.add_argument(
+        'photoslib_dir',
+        help='Path of where the .json and photos were exported')
+    parser.add_argument(
+        'output_dir',
+        help='Path to where the albums and the files will be created/moved')
+    parser.add_argument('digikamdb_dir', nargs='?',
+                        help='Path to where Digikam DB is located')
+
+    try:
+        args = parser.parse_args()
+    except BaseException:
+        sys.exit(2)
+
+    # run(sys.argv[1], sys.argv[2], sys.argv[3])
+    run(args.photoslib_dir, args.output_dir, args.digikamdb_dir)

--- a/photos_export.py
+++ b/photos_export.py
@@ -39,10 +39,8 @@ def run(lib_dir, output_dir, digikam_dir):
     output('Setting EXIF metadata')
     set_exif.run(temp_dir)
 
-    output("ONLY FOR DIGIKAM USERS !\nDo you want to Group Versions ? You need to run Digikam and configure "
-           "repository first !")
-    if askyesno():
-        output('Setting EXIF metadata')
+    if digikam_dir is not None:
+        output('Grouping Versions...')
         group_versions.run(digikam_dir, temp_dir)
 
     output('Exporting Folder Structure')
@@ -70,7 +68,8 @@ if __name__ == '__main__':
 
     try:
         args = parser.parse_args()
-    except BaseException:
+    except Exception as error:
+        print("Argument error: ", error)
         sys.exit(2)
 
     # run(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/photos_export.py
+++ b/photos_export.py
@@ -8,6 +8,7 @@ import folder_structure
 import group_versions
 import album_folder
 import sys
+import os
 from argparse import ArgumentParser
 
 


### PR DESCRIPTION
Little changes. 
1) group_versions.py: the script now does not assume anymore that the DIGIKAM database is in the current directory. The directory is passed by parameter.
2) photos_extract.py: the digikam directory, if passed, calls altomatically group_versions.py. Otherwise, it ignores the script. 
3) README updated
